### PR TITLE
Address #27 - Dedupe in-flight requests and add 2 minute stylesheet caching

### DIFF
--- a/cq-prolyfill.js
+++ b/cq-prolyfill.js
@@ -334,7 +334,7 @@ function loadExternal(href, callback) {
 			CACHE[href] = response || '';
 			setTimeout(function() { delete CACHE[href]; }, CACHE_MAX_AGE);
 
-			IN_FLIGHT[href].forEach((cb) => cb(CACHE[href]));
+			IN_FLIGHT[href].forEach(function(cb) { cb(CACHE[href]); });
 			delete IN_FLIGHT[href];
 		}
 		isDone = true;


### PR DESCRIPTION
To address the duplicated requests, I added deduplication and caching to `loadExternal`.

Using the [awesome minimal test case](http://codepen.io/frxnz/pen/QEQdPW) from @frxnz, I saw 3 XHR requests for each stylesheet. Here is a [fixed test case](http://codepen.io/anon/pen/NpPPzw) showing only 1 request by `loadExternal` for each stylesheet.

I was unable to run your test suite because I could not find the `replace` package on Arch Linux, sorry. :)