### PR TITLE
Memory leak fix

### DIFF
--- a/cq-prolyfill.js
+++ b/cq-prolyfill.js
@@ -242,14 +242,16 @@ function onDomMutate(event) {
 function preprocess(callback) {
 
 	var sheets = arrayFrom(styleSheets);
+
 	// Check removed stylesheets
 	processedSheets.forEach(function(newNode, node) {
-		if (sheets.indexOf(node.sheet) === -1) { // Node has been deleted
-			if (newNode && sheets.indexOf(newNode.sheet) !== -1 && newNode.parentNode) { // Remove from parent
-                sheets.splice(sheets.indexOf(newNode.sheet), 1);
-                newNode.parentNode.removeChild(newNode);
+		// Original stylesheet has been deleted
+		if (sheets.indexOf(node.sheet) === -1) {
+			if (newNode && sheets.indexOf(newNode.sheet) !== -1 && newNode.parentNode) {
+				sheets.splice(sheets.indexOf(newNode.sheet), 1);
+				newNode.parentNode.removeChild(newNode);
 			}
-            processedSheets.delete(node);
+			processedSheets.delete(node);
 		}
 	});
 

--- a/cq-prolyfill.js
+++ b/cq-prolyfill.js
@@ -435,14 +435,16 @@ function resolveRelativeUrl(url, base) {
 function preprocessStyle(node, cssText) {
 	processedSheets.set(node, false);
 	var escapedText = escapeSelectors(cssText);
-	var cssRules = -1;
-	if (escapedText === cssText) { // Check if cssRules is accessible
+	var rulesLength = -1;
+	if (escapedText === cssText) {
 		try {
-			cssRules = node.sheet.cssRules.length;
-		} catch (e) {
-			cssRules = -1;
+			rulesLength = node.sheet.cssRules.length;
 		}
-		if (cssRules === -1) {
+		catch(e) {
+			rulesLength = -1;
+		}
+		// Check if cssRules is accessible
+		if (rulesLength !== -1) {
 			return;
 		}
 	}

--- a/cq-prolyfill.js
+++ b/cq-prolyfill.js
@@ -435,8 +435,16 @@ function resolveRelativeUrl(url, base) {
 function preprocessStyle(node, cssText) {
 	processedSheets.set(node, false);
 	var escapedText = escapeSelectors(cssText);
-	if (escapedText === cssText && (!node || !node.sheet || !node.sheet.cssRules)) { // Check if cssRules is accessible
-		return;
+	var cssRules = -1;
+	if (escapedText === cssText) { // Check if cssRules is accessible
+		try {
+			cssRules = node.sheet.cssRules.length;
+		} catch (e) {
+			cssRules = -1;
+		}
+		if (cssRules === -1) {
+			return;
+		}
 	}
 	var style = createElement('style');
 	style.textContent = escapedText;


### PR DESCRIPTION
When an inline style element is deleted, the reference is kept inside `processedSheets`, creating a memory leak.

Also added a small optimization to avoid a try catch, as [they are a bit expensive](https://stackoverflow.com/questions/38121208/why-cant-v8-optimize-try-catch-finally)

EDIT: Removed try/catch thingy, as tests failed because of that.