### PR TITLE
Fixed parsing of @import stylesheets with Firefox

### DIFF
--- a/cq-prolyfill.js
+++ b/cq-prolyfill.js
@@ -742,6 +742,15 @@ function buildStyleCacheFromRules(rules) {
 		else if (rules[i].cssRules) {
 			buildStyleCacheFromRules(rules[i].cssRules);
 		}
+        else if (rules[i].type === 3) {
+			try {
+				if (rules[i].styleSheet.cssRules)
+					buildStyleCacheFromRules(rules[i].styleSheet.cssRules);
+			}
+			catch (e) {
+				console.log('Error: Container Queries Prolyfill could not parse stylesheets included with @include because of cross-domain access bug of Firefox');
+			}
+        }
 	}
 }
 


### PR DESCRIPTION
Firefox doesn't allow javascript to access styles that were included into a css file with @include.
As a fix I wrapped the code into a try-catch block.