### PR TITLE
Account for possible whitespace

### DIFF
--- a/postcss-plugin.js
+++ b/postcss-plugin.js
@@ -4,9 +4,9 @@ var postcss = require('postcss');
 module.exports = postcss.plugin('cq-prolyfill', function () {
 	'use strict';
 	return function (css) {
-		css.walkRules(/:container\(/i, function (rule) {
+		css.walkRules(/:container\s*\(/i, function (rule) {
 			rule.selectors = rule.selectors.map(function(selector) {
-				return selector.replace(/:container\((?:[^()]+|\([^()]*\))+\)/gi, function(match) {
+				return selector.replace(/:container\s*\((?:[^()]+|\([^()]*\))+\)/gi, function(match) {
 					return '.' + match
 						.replace(/\s+/g, '')
 						.replace(/^:container\("((?:[^()]+|\([^()]*\))+)"\)$/i, ':container($1)')


### PR DESCRIPTION
Currently fails to detect the containerQuery if whitespace is between `:container` and `( ... )` in the example: `&:container ( ... )` - this commit accounts for that potential whitespace, mirroring the behavior of whitespace in `@media ( ... )`.